### PR TITLE
Remove check_previous in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ from setuptools.command.test import test as TestCommand
 import imp
 import logging
 import os
-import pip
 import sys
 
 logger = logging.getLogger(__name__)
@@ -98,15 +97,6 @@ def write_version(filename=os.path.join(*['airflow',
     text = "{}".format(git_version(version))
     with open(filename, 'w') as a:
         a.write(text)
-
-
-def check_previous():
-    installed_packages = ([package.project_name for package
-                           in pip.get_installed_distributions()])
-    if 'airflow' in installed_packages:
-        print("An earlier non-apache version of Airflow was installed, "
-              "please uninstall it first. Then reinstall.")
-        sys.exit(1)
 
 
 async = [
@@ -195,7 +185,6 @@ devel_all = devel + all_dbs + doc + samba + s3 + slack + crypto + oracle + docke
 
 
 def do_setup():
-    check_previous()
     write_version()
     setup(
         name='apache-airflow',


### PR DESCRIPTION
This check has a dependency on an internal pip interface that was
removed in pip 10, therefore our build no longer works using the
CircleCI Python 3.6 image.

This code was removed in [AIRFLOW-1582], and we don't need it anyway as
we're using a containerised Airflow setup, so there's no in-place
upgrades.